### PR TITLE
Sort all index files by domain and title

### DIFF
--- a/index-1-energy.md
+++ b/index-1-energy.md
@@ -3,136 +3,135 @@
 ## Introduction
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psionguild.org | Grounding and Centering \<Tetra> | https://web.archive.org/web/20110705064330/http://psionguild.org:80/education/articles/foundation/grounding-centering |
 | astateofmind.eu | 3 steps to ground yourself \<Nathan> | https://web.archive.org/web/20100426065445/http://astateofmind.eu:80/2010/04/22/3-steps-to-ground-yourself/ | 
-| psistudies.net | Energy Manipulation and Psiballs \<Brandon R> | https://web.archive.org/web/20071223145443/http://psistudies.net:80/_articles_backup/basic-psi-manip.html | 
-| psistudies.net | PsiBall Creation by \<PsiGnome> | https://web.archive.org/web/20071205095307/http://psistudies.net:80/_articles_backup/psiballcreation-psignome.html |
-| psionicsonline.net\/forums | Energy manipulation Practice. \<Forum thread> | https://web.archive.org/web/20080927204311/http://www.psionicsonline.net:80/forums/energy-manipulation-practice | 
-| psionguild.org/forums | Awareness Exercise \<Forum thread> | https://web.archive.org/web/20090105175233/http://www.psionguild.org/forums/archive/index.php/t-1761.html | 
-| psionicsonline.net | Field Refinement \<Archaic\[UPC]> | https://web.archive.org/web/20091117130608/http://www.psionicsonline.net:80/article/field-refinement-archaic-upc | 
-| psionicsonline.net | Basic Energy Management \<Innerfire> | https://web.archive.org/web/20090827005702/http://www.psionicsonline.net:80/article/basic-energy-management-innerfire | 
-| psionguild.org | Basic Psiballs \<Ally> | https://web.archive.org/web/20130122212441/http://psionguild.org:80/education/articles/constructs/basic-psiballs | 
-| freewebs.com/jedikaren | The First Psi Ball \<Maticolotto> | https://web.archive.org/web/20070510050059/http://www.freewebs.com:80/jedikaren/firstpsiball.htm |
 | forums.vsociety.net | Energy Manipulation Guide [1/3] \<ChezNips> | https://web.archive.org/web/20190623182335/http://forums.vsociety.net/index.php/topic,10829.0.html |
 | forums.vsociety.net | Energy Manipulation Guide [2/3] \<ChezNips> | https://web.archive.org/web/20190623185019/http://forums.vsociety.net/index.php/topic,10829.15.html |
 | forums.vsociety.net | Energy Manipulation Guide [3/3] \<ChezNips> | https://web.archive.org/web/20190625002101/http://forums.vsociety.net/index.php/topic,10829.30.html |
-| shiftedperspectives.net | Psi Balls and Basic Constructs \<Dangpp> | https://web.archive.org/web/20120423020201/http://shiftedperspectives.net/articles.php?id=7 |
-| shiftedperspectives.net | The Flow of Psi \<_multiple authors_> | https://web.archive.org/web/20120423020201/http://shiftedperspectives.net/articles.php?id=9 |
-| psipalatium.com | Moving your Energy \<ChezNips> | [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=605&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230603044206/http://www.psipalatium.com/index.php?p=200&a=605&l1=2&l2=21) |
+| freewebs.com/jedikaren | The First Psi Ball \<Maticolotto> | https://web.archive.org/web/20070510050059/http://www.freewebs.com:80/jedikaren/firstpsiball.htm |
+| psionguild.org | Basic Psiballs \<Ally> | https://web.archive.org/web/20130122212441/http://psionguild.org:80/education/articles/constructs/basic-psiballs | 
+| psionguild.org | Grounding and Centering \<Tetra> | https://web.archive.org/web/20110705064330/http://psionguild.org:80/education/articles/foundation/grounding-centering |
+| psionguild.org/forums | Awareness Exercise \<Forum thread> | https://web.archive.org/web/20090105175233/http://www.psionguild.org/forums/archive/index.php/t-1761.html | 
+| psionicsonline.net | Basic Energy Management \<Innerfire> | https://web.archive.org/web/20090827005702/http://www.psionicsonline.net:80/article/basic-energy-management-innerfire | 
+| psionicsonline.net | Field Refinement \<Archaic\[UPC]> | https://web.archive.org/web/20091117130608/http://www.psionicsonline.net:80/article/field-refinement-archaic-upc | 
+| psionicsonline.net/forums | Energy manipulation Practice. \<Forum thread> | https://web.archive.org/web/20080927204311/http://www.psionicsonline.net:80/forums/energy-manipulation-practice | 
+| psipalatium.com | Beginning with Psi \<Zeus> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=245&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20220516205022/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=245&a1=&p1=&g1=&gp1=&s1=&s=1) |
 | psipalatium.com | Getting Started \<ChezNips> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=550&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20180206174325/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=550&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) |
+| psipalatium.com | How-To-Shield \<ChezNips> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=556&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230324034329/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=556&a1=&p1=&g1=&gp1=&s1=&s=1) |
+| psipalatium.com | Programming Constructs/Thoughtforms \<ChezNips> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=557&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230603051727/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=557&a1=&p1=&g1=&gp1=&s1=&s=1) |
+| psipalatium.com | Psionics \<WingedWolf> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=258&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20220517001852/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=258&a1=&p1=&g1=&gp1=&s1=&s=1) |
+| psipalatium.com | Moving your Energy \<ChezNips> | [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=605&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230603044206/http://www.psipalatium.com/index.php?p=200&a=605&l1=2&l2=21) |
 | psipalatium.com | Threads \<ChezNips> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=552&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230126223628/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=552&a1=&p1=&g1=&gp1=&s1=&s=1) |
 | psipalatium.com | Tracing \<ChezNips> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=554&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20231204134330/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=554&a1=&p1=&g1=&gp1=&s1=&s=1) |
-| psipalatium.com | Programming Constructs/Thoughtforms \<ChezNips> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=557&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230603051727/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=557&a1=&p1=&g1=&gp1=&s1=&s=1) |
-| psipalatium.com | How-To-Shield \<ChezNips> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=556&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230324034329/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=556&a1=&p1=&g1=&gp1=&s1=&s=1) |
-| psipalatium.com | Beginning with Psi \<Zeus> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=245&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20220516205022/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=245&a1=&p1=&g1=&gp1=&s1=&s=1) |
-| psipalatium.com | Psionics \<WingedWolf> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=258&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20220517001852/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=258&a1=&p1=&g1=&gp1=&s1=&s=1) |
+| psistudies.net | Energy Manipulation and Psiballs \<Brandon R> | https://web.archive.org/web/20071223145443/http://psistudies.net:80/_articles_backup/basic-psi-manip.html | 
+| psistudies.net | PsiBall Creation by \<PsiGnome> | https://web.archive.org/web/20071205095307/http://psistudies.net:80/_articles_backup/psiballcreation-psignome.html |
+| shiftedperspectives.net | Psi Balls and Basic Constructs \<Dangpp> | https://web.archive.org/web/20120423020201/http://shiftedperspectives.net/articles.php?id=7 |
+| shiftedperspectives.net | The Flow of Psi \<_multiple authors_> | https://web.archive.org/web/20120423020201/http://shiftedperspectives.net/articles.php?id=9 |
 
 
 ## Charging and Cultivation
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
+| freewebs.com/jedikaren | The Flow of Psi \<no credit given> | https://web.archive.org/web/20070529181721/http://www.freewebs.com:80/jedikaren/flow.htm |
+| psionguild.org | How To Charge \<Winged Wolf> | https://web.archive.org/web/20120214163626/http://psionguild.org:80/education/articles/foundation/how-to-charge |
+| psionicsonline.net | Gathering Psi \<Roger Demis> | https://web.archive.org/web/20080313094759/http://www.psionicsonline.net/gatheringpsiroger |
 | psistudies.net | Charging by \<3k> | https://web.archive.org/web/20071223145448/http://psistudies.net:80/_articles_backup/charging-3k.html | 
 | psistudies.net | Mind Feeding \<Mordak> | https://web.archive.org/web/20071205095247/http://psistudies.net:80/_articles_backup/mindfeeding-mordak.html |
-| psionicsonline.net | Gathering Psi \<Roger Demis> | https://web.archive.org/web/20080313094759/http://www.psionicsonline.net/gatheringpsiroger |
-| psionguild.org | How To Charge \<Winged Wolf> | https://web.archive.org/web/20120214163626/http://psionguild.org:80/education/articles/foundation/how-to-charge |
 | thepsiworld.proboards37.com | Gathering \<Forum thread> | https://web.archive.org/web/20070527044113/http://thepsiworld.proboards37.com:80/index.cgi?board=gpsi&action=display&thread=1177624130 |
-| freewebs.com/jedikaren | The Flow of Psi \<no credit given> | https://web.archive.org/web/20070529181721/http://www.freewebs.com:80/jedikaren/flow.htm |
 
 
 ## Constructs and Programming
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psistudies.net | Understanding Constructs \<XPWarrior3> | https://web.archive.org/web/20071205095224/http://psistudies.net:80/_articles_backup/constructs-xpw3.html | 
-| psistudies.net | Basic Programming, Simplified \<Miri> | https://web.archive.org/web/20071205095257/http://psistudies.net:80/_articles_backup/programming-simplified-miri.html | 
-| psistudies.net | Practicing programming without making constructs \<Miri> | https://web.archive.org/web/20071205095252/http://psistudies.net:80/_articles_backup/programming-practice-miri.html | 
-| psionicsonline.net | Constructs for Newbies \<Lesenthe> | https://web.archive.org/web/20091009095620/http://www.psionicsonline.net:80/article/constructs-newbies-lesenthe | 
-| psionicsonline.net | Basic Energy Programming \<Hech \[UPC]> | https://web.archive.org/web/20111212201942/http://www.psionicsonline.net/basic-energy-programming-upc/ | 
-| psionicsonline.net | Planning and Programming \<Lesenthe> | https://web.archive.org/web/20130710233943/http://psionicsonline.net:80/book/export/html/7322 | 
-| psionicsonline.net | Designing Constructs \<Miri> | https://web.archive.org/web/20111212201944/http://www.psionicsonline.net/designing-constructs/ |
-| psionicsonline.net | Binding Constructs to Objects \<Shadowarrior13 \[UPC]> | https://web.archive.org/web/20091117130600/http://www.psionicsonline.net:80/article/binding-constructs-objects-shadowarrior13-upc | 
-| psionicsonline.net\/forums | Interesting area of effect enchantment or programming, in your private space \<Forum thread> | https://web.archive.org/web/20110524030000/http://www.psionicsonline.net:80/forums/index.php/topic,2868.0.html | 
-| psionicsonline.net | Advanced Energy Manipulation and Programming \<Hech\[UPC]> | https://web.archive.org/web/20111212201947/http://www.psionicsonline.net/advanced-energy-manipulation-and-programming-upc/ |
-| psionguild.org | Construct Creation \<Winged Wolf> | https://web.archive.org/web/20130122212453/http://psionguild.org:80/education/articles/constructs/construct-creation | 
-| psionguild.org | Basic Construct Design and Programming \<Anayan> | https://web.archive.org/web/20130124030743/http://psionguild.org:80/education/articles/constructs/basic-construct-design-programming | 
 | astateofmind.eu | Shelling \<Hech \[UPC]> | https://web.archive.org/web/20100202212950/http://astateofmind.eu:80/2008/12/07/shelling |
-| psc-online.org | Energetic Cords and Tendrils \<Rainsong> | https://web.archive.org/web/20180507171922/http://psc-online.org/doku.php?id=blog:tendrils |
 | forums.vsociety.net | Programming Constructs/Thoughtforms \<ChezNips> | https://web.archive.org/web/20100707165358/http://forums.vsociety.net/index.php/topic,10838.0.html |
 | miripsion.googlepages.com | Advanced constructs - A brief guide to the daunting \<miri> | https://web.archive.org/web/20090607140830/http://miripsion.googlepages.com:80/advancedconstructs |
+| psc-online.org | Energetic Cords and Tendrils \<Rainsong> | https://web.archive.org/web/20180507171922/http://psc-online.org/doku.php?id=blog:tendrils |
+| psionguild.org | Basic Construct Design and Programming \<Anayan> | https://web.archive.org/web/20130124030743/http://psionguild.org:80/education/articles/constructs/basic-construct-design-programming | 
+| psionguild.org | Construct Creation \<Winged Wolf> | https://web.archive.org/web/20130122212453/http://psionguild.org:80/education/articles/constructs/construct-creation | 
+| psionicsonline.net | Advanced Energy Manipulation and Programming \<Hech\[UPC]> | https://web.archive.org/web/20111212201947/http://www.psionicsonline.net/advanced-energy-manipulation-and-programming-upc/ |
+| psionicsonline.net | Basic Energy Programming \<Hech \[UPC]> | https://web.archive.org/web/20111212201942/http://www.psionicsonline.net/basic-energy-programming-upc/ | 
+| psionicsonline.net | Binding Constructs to Objects \<Shadowarrior13 \[UPC]> | https://web.archive.org/web/20091117130600/http://www.psionicsonline.net:80/article/binding-constructs-objects-shadowarrior13-upc | 
+| psionicsonline.net | Constructs for Newbies \<Lesenthe> | https://web.archive.org/web/20091009095620/http://www.psionicsonline.net:80/article/constructs-newbies-lesenthe | 
+| psionicsonline.net | Designing Constructs \<Miri> | https://web.archive.org/web/20111212201944/http://www.psionicsonline.net/designing-constructs/ |
+| psionicsonline.net | Planning and Programming \<Lesenthe> | https://web.archive.org/web/20130710233943/http://psionicsonline.net:80/book/export/html/7322 | 
+| psionicsonline.net/forums | Interesting area of effect enchantment or programming, in your private space \<Forum thread> | https://web.archive.org/web/20110524030000/http://www.psionicsonline.net:80/forums/index.php/topic,2868.0.html | 
+| psipalatium.com | Energy Tagging for ID \<ChezNips> | [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=607&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230603054122/http://www.psipalatium.com/index.php?p=200&a=607&l1=2&l2=21) |
 | psiscape.net | Making Constructs: To Add-In All Programs Conciously or Not? \<Forum thread> | https://web.archive.org/web/20060104114845/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=420&amp;sid=50acb108e615e6a42354c460329cc376 |
+| psistudies.net | Basic Programming, Simplified \<Miri> | https://web.archive.org/web/20071205095257/http://psistudies.net:80/_articles_backup/programming-simplified-miri.html | 
+| psistudies.net | Practicing programming without making constructs \<Miri> | https://web.archive.org/web/20071205095252/http://psistudies.net:80/_articles_backup/programming-practice-miri.html | 
+| psistudies.net | Understanding Constructs \<XPWarrior3> | https://web.archive.org/web/20071205095224/http://psistudies.net:80/_articles_backup/constructs-xpw3.html | 
 | shiftedperspectives.net | Understanding Constructs \<XPWarrior3> | https://web.archive.org/web/20120423020202/http://shiftedperspectives.net/articles.php?id=8 |
 | zhkyrl.brinkster.net/psionline | A Shelling Guide \<Hech> | https://web.archive.org/web/20070105082250/http://zhkyrl.brinkster.net:80/psionline/c_shelling.html |
-| psipalatium.com | Energy Tagging for ID \<ChezNips> | [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=607&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230603054122/http://www.psipalatium.com/index.php?p=200&a=607&l1=2&l2=21) |
-
 
 
 ## Shielding
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psionicsonline.net | Basic Shielding Techniques \<Magicdood> | https://web.archive.org/web/20080411092818/http://www.psionicsonline.net/basicshieldingtechniques | 
-| psionicsonline.net | Shielding 101 \<Zeus> | https://web.archive.org/web/20091117130616/http://www.psionicsonline.net:80/article/shielding-101-zeus | 
+| forums.vsociety.net | How to Shield \<ChezNips> | https://web.archive.org/web/20100707170046/http://forums.vsociety.net/index.php/topic,10831.0.html |
+| forums.vsociety.net | I would like to share an article on shielding if I may \<Sigma> | https://web.archive.org/web/20130719183900/http://forums.vsociety.net/index.php/topic,10094.0/prev_next,next.html |
+| forums.vsociety.net | Shielding: The Dynamic Psi Perspective \<Kettle> | https://web.archive.org/web/20140703005508/http://forums.vsociety.net/index.php/topic,14903.0.html |
+| freewebs.com/jedikaren | How-to-guide for shielding \<NeoPsychic> | https://web.archive.org/web/20071221045444/http://www.freewebs.com:80/jedikaren/shields.htm |
 | psionguild.org | Elementary Psionic Shielding \<Vladimir> | https://web.archive.org/web/20120214163811/http://psionguild.org:80/education/articles/defense-combat/elementary-psionic-shielding | 
 | psionguild.org | Shielding <Winged Wolf, Anka> | https://web.archive.org/web/20131011134539/http://psionguild.org/education/articles/defense-combat/shielding/ | 
-| thepsiworld.proboards37.com | Consecration \[Shielding technique] \<Intrigue> | https://web.archive.org/web/20070527043733/http://thepsiworld.proboards37.com:80/index.cgi?board=shie&action=display&thread=1175316762 |
-| freewebs.com/jedikaren | How-to-guide for shielding \<NeoPsychic> | https://web.archive.org/web/20071221045444/http://www.freewebs.com:80/jedikaren/shields.htm |
 | psc-online.org | Stone Tower Shields, and About Shielding Generally \<Rainsong> | https://web.archive.org/web/20180507171401/http://psc-online.org/doku.php?id=blog:stone_tower_shield |
-| forums.vsociety.net | How to Shield \<ChezNips> | https://web.archive.org/web/20100707170046/http://forums.vsociety.net/index.php/topic,10831.0.html |
-| forums.vsociety.net | Shielding: The Dynamic Psi Perspective \<Kettle> | https://web.archive.org/web/20140703005508/http://forums.vsociety.net/index.php/topic,14903.0.html |
-| forums.vsociety.net | I would like to share an article on shielding if I may \<Sigma> | https://web.archive.org/web/20130719183900/http://forums.vsociety.net/index.php/topic,10094.0/prev_next,next.html |
+| psionicsonline.net | Basic Shielding Techniques \<Magicdood> | https://web.archive.org/web/20080411092818/http://www.psionicsonline.net/basicshieldingtechniques | 
+| psionicsonline.net | Shielding 101 \<Zeus> | https://web.archive.org/web/20091117130616/http://www.psionicsonline.net:80/article/shielding-101-zeus | 
 | thepsiworld.net | Basic Shielding Techniques and Thinking in Concepts by Anuboern \<Fearn> | https://web.archive.org/web/20090220084935/http://www.thepsiworld.net:80/forum/index.php/topic,2515.0/prev_next,prev.html |
+| thepsiworld.proboards37.com | Consecration \[Shielding technique] \<Intrigue> | https://web.archive.org/web/20070527043733/http://thepsiworld.proboards37.com:80/index.cgi?board=shie&action=display&thread=1175316762 |
 | zhkyrl.brinkster.net/psionline | A Newbie's Guide to Shielding \<Stony1205> | https://web.archive.org/web/20070106000919/http://zhkyrl.brinkster.net:80/psionline/b_shield.html |
 
 
 ## Sensitivity, Perception, and Scanning
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
+| artofpsionics.proboards.com | Sensing Article \<Stolide> | https://web.archive.org/web/20230721065555/https://artofpsionics.proboards.com/thread/143/sensing-article |
+| astateofmind.eu | How to use your memories to improve clairvoyance \<Nathaniel> | https://web.archive.org/web/20101213024804/http://astateofmind.eu:80/2010/12/03/memories-improve-clairvoyance/ |
+| astateofmind.eu | Remote Viewing: A Look Upon the Abstract \<DagoRed \[UPC]> | https://web.archive.org/web/20081207053358/http://astateofmind.eu:80/2008/12/05/remote-viewing-a-look-upon-the-abstract/ |
+| astateofmind.eu | Rudimentary Scanning \<Jaci \[UPC]> | https://web.archive.org/web/20100204151549/http://astateofmind.eu:80/2008/12/06/rudimentary-scanning/ |
+| freewebs.com/jedikaren | Remote Viewing \<JediKaren> | https://web.archive.org/web/20071020184806/http://www.freewebs.com:80/jedikaren/rv.htm |
+| psionguild.org | Awareness Exercise \<Winged Wolf> | https://web.archive.org/web/20120215121420/http://psionguild.org:80/education/articles/foundation/awareness-exercise | 
+| psionguild.org | Drop and Drift Method \<KMiller> | https://web.archive.org/web/20120215145746/http://psionguild.org:80/education/articles/physical-abilities/drop-drift-method/ |
 | psionguild.org | Energy Sensing \<Winged Wolf> | https://web.archive.org/web/20120209204136/http://psionguild.org:80/education/articles/foundation/energy-sensing |
-| psionicsonline.net | Awareness and Sensitivity \<Intrepid> | https://web.archive.org/web/20111212202032/http://www.psionicsonline.net/awareness-and-sensitivity/ | 
+| psionguild.org | Scanning Constructs and Energy \<Vladimir> | https://web.archive.org/web/20110706063911/http://psionguild.org:80/education/articles/constructs/scanning-constructs-energy/ | 
 | psionicsonline.net | Analytic Overlay \<JoeRoger \[UPC]> | https://web.archive.org/web/20091117120457/http://www.psionicsonline.net:80/article/analytic-overlay-joeroger-upc |
-| psionicsonline.net | The Basics of Awareness and Sensitivity \<Neveza> | https://web.archive.org/web/20080913194911/http://www.psionicsonline.net:80/content/basics-awareness-and-sensitivity-neveza |
-| psionicsonline.net | How to Receive Anything \<Peebrain> | https://web.archive.org/web/20110930064625/http://www.psionicsonline.net:80/how-to-receive-anything/ |
-| psionicsonline.net | Remote Presence, Viewing and Touch \<Lesenthe> | https://web.archive.org/web/20080827125245/http://www.psionicsonline.net:80/content/remote-presence-viewing-and-touch-lesenthe | 
-| psionicsonline.net/forums | Mental Interaction, Symbolism, and Assocation \<Forum thread> | https://web.archive.org/web/20091029222622/http://www.psionicsonline.net:80/forums/mental-interaction-symbolism-and-assocation | 
+| psionicsonline.net | Awareness and Sensitivity \<Intrepid> | https://web.archive.org/web/20111212202032/http://www.psionicsonline.net/awareness-and-sensitivity/ | 
+| psionicsonline.net | Beneath the Construct \<Lesenthe> | https://web.archive.org/web/20111109040153/http://www.psionicsonline.net:80/beneath-the-construct-revised/ |
 | psionicsonline.net | Blank Mind Scanning \<Miri> | https://web.archive.org/web/20091119003031/http://www.psionicsonline.net:80/article/blank-mind-scanning-miri |
 | psionicsonline.net | \[PART 1] Different Views: Physical to Non-Physical: E.S.P \<Float> | https://web.archive.org/web/20111212202029/http%253A//www.psionicsonline.net/different-views-physical-to-non-physical-esp/ | 
 | psionicsonline.net | \[PART 2] Different Views: Physical to Non-Physical: E.S.P \<Float> | https://web.archive.org/web/20111212202030/http://www.psionicsonline.net/different-views-physical-to-non-physical-esp-part-2/ |
-| psionicsonline.net | Beneath the Construct \<Lesenthe> | https://web.archive.org/web/20111109040153/http://www.psionicsonline.net:80/beneath-the-construct-revised/ |
+| psionicsonline.net | How to Receive Anything \<Peebrain> | https://web.archive.org/web/20110930064625/http://www.psionicsonline.net:80/how-to-receive-anything/ |
+| psionicsonline.net | Remote Presence, Viewing and Touch \<Lesenthe> | https://web.archive.org/web/20080827125245/http://www.psionicsonline.net:80/content/remote-presence-viewing-and-touch-lesenthe | 
+| psionicsonline.net | The Basics of Awareness and Sensitivity \<Neveza> | https://web.archive.org/web/20080913194911/http://www.psionicsonline.net:80/content/basics-awareness-and-sensitivity-neveza |
 | psionicsonline.net/forums | Intuition \<Forum thread> | https://web.archive.org/web/20080917081307/http://www.psilinks.net:80/forum/index.php/topic,97.0.html | 
-| psionguild.org | Scanning Constructs and Energy \<Vladimir> | https://web.archive.org/web/20110706063911/http://psionguild.org:80/education/articles/constructs/scanning-constructs-energy/ | 
-| psionguild.org | Awareness Exercise \<Winged Wolf> | https://web.archive.org/web/20120215121420/http://psionguild.org:80/education/articles/foundation/awareness-exercise | 
-| psionguild.org | Drop and Drift Method \<KMiller> | https://web.archive.org/web/20120215145746/http://psionguild.org:80/education/articles/physical-abilities/drop-drift-method/ |
-| thepsiworld.proboards37.com | a little game \<GEOvanne> | https://web.archive.org/web/20070526025853/http://thepsiworld.proboards37.com:80/index.cgi?board=foreseeing&action=display&thread=1169485075 |
-| thepsiworld.proboards37.com | The way to scan explained \<durial> | https://web.archive.org/web/20071011182857/http://thepsiworld.proboards37.com:80/index.cgi?board=scan&action=display&thread=1190506343&page=1 |
-| artofpsionics.proboards.com | Sensing Article \<Stolide> | https://web.archive.org/web/20230721065555/https://artofpsionics.proboards.com/thread/143/sensing-article |
-| freewebs.com/jedikaren | Remote Viewing \<JediKaren> | https://web.archive.org/web/20071020184806/http://www.freewebs.com:80/jedikaren/rv.htm |
-| astateofmind.eu | Remote Viewing: A Look Upon the Abstract \<DagoRed \[UPC]> | https://web.archive.org/web/20081207053358/http://astateofmind.eu:80/2008/12/05/remote-viewing-a-look-upon-the-abstract/ |
-| astateofmind.eu | Rudimentary Scanning \<Jaci \[UPC]> | https://web.archive.org/web/20100204151549/http://astateofmind.eu:80/2008/12/06/rudimentary-scanning/ |
-| astateofmind.eu | How to use your memories to improve clairvoyance \<Nathaniel> | https://web.archive.org/web/20101213024804/http://astateofmind.eu:80/2010/12/03/memories-improve-clairvoyance/ |
-| psiscape.net | Scanning and reporting on scan [in parallel] \<Forum thread> | https://web.archive.org/web/20060104112312/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=241&amp;sid=b0d6706e86eae33b7931687a73506cbe |
-| psiscape.net | Moving awarness, increasing sensitivity \<Forum thread> | https://web.archive.org/web/20060104114343/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=284&amp;sid=b0d6706e86eae33b7931687a73506cbe |
-| psiscape.net | Sensitivity [training methods] \<Forum thread> | https://web.archive.org/web/20060104115101/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=442&amp;sid=b0d6706e86eae33b7931687a73506cbe |
+| psionicsonline.net/forums | Mental Interaction, Symbolism, and Assocation \<Forum thread> | https://web.archive.org/web/20091029222622/http://www.psionicsonline.net:80/forums/mental-interaction-symbolism-and-assocation | 
+| psipalatium.com | Scanning \<Zeus, Forg> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=531&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20210517132319/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=531&a1=&p1=&g1=&gp1=&s1=&s=1) |
 | psiscape.net | Increasing Sensitivity... \<Forum thread> | https://web.archive.org/web/20060104165656/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=182&amp;sid=641e3c2f0e6bd2ed12cd9f5206a934e2 |
+| psiscape.net | Moving awarness, increasing sensitivity \<Forum thread> | https://web.archive.org/web/20060104114343/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=284&amp;sid=b0d6706e86eae33b7931687a73506cbe |
+| psiscape.net | Scanning and reporting on scan [in parallel] \<Forum thread> | https://web.archive.org/web/20060104112312/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=241&amp;sid=b0d6706e86eae33b7931687a73506cbe |
+| psiscape.net | Sensitivity [training methods] \<Forum thread> | https://web.archive.org/web/20060104115101/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=442&amp;sid=b0d6706e86eae33b7931687a73506cbe |
 | shiftedperspectives.net | Feeling and Using Psi \<Orion> | https://web.archive.org/web/20120423020200/http://shiftedperspectives.net/articles.php?id=83 |
 | shiftedperspectives.net | On Psychological Interpretations of Subtle Energy \<Stolide Demens> | https://web.archive.org/web/20120423020215/http://shiftedperspectives.net/articles.php?id=110 |
-| psipalatium.com | Scanning \<Zeus, Forg> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=531&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20210517132319/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=531&a1=&p1=&g1=&gp1=&s1=&s=1) |
+| thepsiworld.proboards37.com | a little game \<GEOvanne> | https://web.archive.org/web/20070526025853/http://thepsiworld.proboards37.com:80/index.cgi?board=foreseeing&action=display&thread=1169485075 |
+| thepsiworld.proboards37.com | The way to scan explained \<durial> | https://web.archive.org/web/20071011182857/http://thepsiworld.proboards37.com:80/index.cgi?board=scan&action=display&thread=1190506343&page=1 |
 
 
 ## Healing
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psionicsonline.net | The Basics of Healing \<Neveza> | https://web.archive.org/web/20080415212124/http://www.psionicsonline.net/basicsofhealingneveza | 
-| psistudies.net | Healing Technique \<Psi_Ninja> | https://web.archive.org/web/20071205095236/http://psistudies.net:80/_articles_backup/healing_psininja.html | 
 | artofpsionics.proboards.com | Healing and Your Energy Body \<Spilledchemicals> | https://web.archive.org/web/20230721065053/https://artofpsionics.proboards.com/thread/63/healing-energy-body |
 | freewebs.com/jedikaren | About Healing \<JediKaren> | https://web.archive.org/web/20071022021149/http://freewebs.com:80/jedikaren/abouthealing.htm |
 | freewebs.com/jedikaren | Healing Headaches \<JediKaren> | https://web.archive.org/web/20071022021154/http://freewebs.com:80/jedikaren/headaches.htm |
 | freewebs.com/jedikaren | Numbing \<JediKaren> | https://web.archive.org/web/20071022021159/http://freewebs.com:80/jedikaren/numbing.htm |
+| psionicsonline.net | The Basics of Healing \<Neveza> | https://web.archive.org/web/20080415212124/http://www.psionicsonline.net/basicsofhealingneveza | 
+| psistudies.net | Healing Technique \<Psi_Ninja> | https://web.archive.org/web/20071205095236/http://psistudies.net:80/_articles_backup/healing_psininja.html | 
 
 
 ## Construct Applications
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
+| forums.vsociety.net | The Secondary Cerebral Cortex of the Psion \<Kettle> | https://web.archive.org/web/20190623185029/http://forums.vsociety.net/index.php/topic,11619.0.html |
 | psionguild.org | Psionic Construct Applications \<KMiller> | https://web.archive.org/web/20130122212516/http://psionguild.org:80/education/articles/constructs/psionic-construct-applications | 
 | psionguild.org | Shopping Mall Energy Node \<Winged Wolf> | https://web.archive.org/web/20130124030836/http://psionguild.org:80/education/articles/constructs/shopping-mall-energy-node | 
 | psionguild.org | Wards \<Anka> | https://web.archive.org/web/20131011115833/http://psionguild.org/education/articles/defense-combat/wards/ |
 | psionicsonline.net | Three Easy Steps to: Flaring \<Jynx493> | https://web.archive.org/web/20080411092822/http://www.psionicsonline.net:80/flaring | 
-| forums.vsociety.net | The Secondary Cerebral Cortex of the Psion \<Kettle> | https://web.archive.org/web/20190623185029/http://forums.vsociety.net/index.php/topic,11619.0.html |
 | shiftedperspectives.net | Cloaking Shields \<Stolide Demens> | https://web.archive.org/web/20120423020159/http://shiftedperspectives.net/articles.php?id=98 |

--- a/index-2-telepathy.md
+++ b/index-2-telepathy.md
@@ -3,42 +3,42 @@
 # Empathy
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psionicsonline.net/forums | Controlling Empathy \<Forum thread> | https://web.archive.org/web/20080317090043/http://www.psionicsonline.net:80/forums/index.php/topic,280.0.html | 
-| psionicsonline.net | Empathic Broadcasting \<Jaci> | https://web.archive.org/web/20080916005724/http://www.psionicsonline.net:80/content/empathic-broadcasting-jaci | 
 | artofpsionics.proboards.com | Art of Emotions "Empathy" \<Drynal> | https://web.archive.org/web/20230721065906/https://artofpsionics.proboards.com/thread/89/art-emotions-empathy |
 | freewebs.com/jedikaren | The Cursed Gift \<JediKaren> | https://web.archive.org/web/20071222002831/http://www.freewebs.com:80/jedikaren/generalempathy.htm |
 | psc-online.org | Empathy \<Rainsong> | https://web.archive.org/web/20180507171851/http://psc-online.org/doku.php?id=blog:empathy |
+| psionicsonline.net | Empathic Broadcasting \<Jaci> | https://web.archive.org/web/20080916005724/http://www.psionicsonline.net:80/content/empathic-broadcasting-jaci | 
+| psionicsonline.net/forums | Controlling Empathy \<Forum thread> | https://web.archive.org/web/20080317090043/http://www.psionicsonline.net:80/forums/index.php/topic,280.0.html | 
 | psipalatium.com | Empathy and its Use \<ChezNips> | [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=606&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20230605110652/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=606&a1=&p1=&g1=&gp1=&s1=&s=1) |
 
 
 # Telepathy
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
+| astateofmind.eu | How to Learn Telepathy \<Shadowarrior13 \[UPC], Hech \[UPC]> | https://web.archive.org/web/20100327103229/http://astateofmind.eu:80/2008/11/29/how-to-learn-telepathy/ | 
+| forums.vsociety.net | Telepathy Exercise \<kobok> | https://web.archive.org/web/20130510084247/http%253A//forums.vsociety.net/index.php?topic%253D4829.0 | 
+| hearxmexpsi.blogspot.com | Telepathy Article \<Nervous> | https://web.archive.org/web/20240219015027/http://hearxmexpsi.blogspot.com/2009/06/never-worked-day-in-my-life.html |
+| psc-online.org | Sending \<Rainsong> | https://web.archive.org/web/20180507171914/http://psc-online.org/doku.php?id=blog:sending |
+| psionguild.org | How To Create Psionic Links \<Winged Wolf> | https://web.archive.org/web/20120215121441/http://psionguild.org:80/education/articles/foundation/how-to-create-psionic-links | 
+| psionguild.org | The Telepathy Manual \<Keith Miller, Myriad, Rainsong> | https://web.archive.org/web/20120214154249/http://psionguild.org:80/education/articles/mental-abilities/telepathy-manual | 
+| psionics.net16.net | Some Observations on Telepathy \[ [*See notes*](./index-domains.md#psionicsinstituteorg) ] \<Kath> | https://web.archive.org/web/20110302133752/http://psionics.net16.net:80/forum/viewthread.php?thread_id=50&pid=184 |
 | psionicsonline.net | Psionic Signatures \<Lidless_i \[UPC]> | https://web.archive.org/web/20091117130611/http://www.psionicsonline.net:80/article/psionic-signatures-lidlessi-upc
 | psionicsonline.net | The Basics of Telepathy \<Neveza> | https://web.archive.org/web/20081013023705/http://www.psionicsonline.net/content/basics-telepathy-neveza |
 | psionicsonline.net | The Basics of Telepathy \<Sheepking \[UPC]> | https://web.archive.org/web/20091119002551/http://www.psionicsonline.net:80/article/basics-telepathy-sheepking-upc | 
-| psionguild.org | The Telepathy Manual \<Keith Miller, Myriad, Rainsong> | https://web.archive.org/web/20120214154249/http://psionguild.org:80/education/articles/mental-abilities/telepathy-manual | 
-| psionguild.org | How To Create Psionic Links \<Winged Wolf> | https://web.archive.org/web/20120215121441/http://psionguild.org:80/education/articles/foundation/how-to-create-psionic-links | 
-| astateofmind.eu | How to Learn Telepathy \<Shadowarrior13 \[UPC], Hech \[UPC]> | https://web.archive.org/web/20100327103229/http://astateofmind.eu:80/2008/11/29/how-to-learn-telepathy/ | 
-| psc-online.org | Sending \<Rainsong> | https://web.archive.org/web/20180507171914/http://psc-online.org/doku.php?id=blog:sending |
-| forums.vsociety.net | Telepathy Exercise \<kobok> | https://web.archive.org/web/20130510084247/http%253A//forums.vsociety.net/index.php?topic%253D4829.0 | 
-| psiontemple.proboards.com | Telepathy \<Orion> | https://web.archive.org/web/20180312020552/http://psiontemple.proboards.com/thread/98/lesson-6-telepathy?page=1 | 
 | psiontemple.proboards.com | Telepathic Suggestion \<Orion> | https://web.archive.org/web/20160708163347/http://psiontemple.proboards.com/thread/99/lesson-6-5-telepathic-suggestion | 
+| psiontemple.proboards.com | Telepathy \<Orion> | https://web.archive.org/web/20180312020552/http://psiontemple.proboards.com/thread/98/lesson-6-telepathy?page=1 | 
 | shiftedperspectives.net | I don't know if you guys do [telepathic suggestion] like this but.... \<Forum thread> | https://web.archive.org/web/20101223094531/http://shiftedperspectives.net/forum/index.php/topic,972.0.html |
 | shiftedperspectives.net | Sending and Receiving \<Stolide Demens> | https://web.archive.org/web/20120423020211/http://shiftedperspectives.net/articles.php?id=100 |
-| hearxmexpsi.blogspot.com | Telepathy Article \<Nervous> | https://web.archive.org/web/20240219015027/http://hearxmexpsi.blogspot.com/2009/06/never-worked-day-in-my-life.html |
-| psionics.net16.net | Some Observations on Telepathy \[ [*See notes*](./index-domains.md#psionicsinstituteorg) ] \<Kath> | https://web.archive.org/web/20110302133752/http://psionics.net16.net:80/forum/viewthread.php?thread_id=50&pid=184 |
 
 
 # Other 
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psionguild.org/forums | Dreamwalking Question \<Forum thread> | https://web.archive.org/web/20140223155048/http://psionguild.org:80/forums/archive/index.php/t-2615.html | 
-| psionicsonline.net/forums | Empathic chain? \<Forum thread> | https://web.archive.org/web/20080917050453/http://www.psionicsonline.net:80/forums/empathic-chain | 
-| psilinks.net/forum | Telepathy With Animals \<Forum thread> | https://web.archive.org/web/20080307025152/http://www.psilinks.net:80/forum/index.php/topic,204.0.html | 
-| psilinks.net/forum | Telepathic Illusion or what? \<Forum thread> | https://web.archive.org/web/20081005173939/http://www.psilinks.net:80/forum/index.php/topic,472.0.html | 
-| psilinks.net/forum | \[Ethics of] Mind control \<Forum thread> | https://web.archive.org/web/20080917081731/http://www.psilinks.net:80/forum/index.php/topic,50.0.html |
-| psionguild.org/forums | Telepathy and Empathy...with pets \<Forum thread> | https://web.archive.org/web/20140221140348/http://psionguild.org:80/forums/archive/index.php/t-4843.html |
-| psionguild.org/forums | Physical Possession \<Forum thread> | https://web.archive.org/web/20140224020657/http://psionguild.org:80/forums/archive/index.php/t-7637.html |
 | forums.vsociety.net | Telepathy conundrum \[foreign languages] \<Forum thread> | https://web.archive.org/web/20100707181143/http://forums.vsociety.net/index.php/topic,10974.0/prev_next,next.html | 
+| psilinks.net/forum | \[Ethics of] Mind control \<Forum thread> | https://web.archive.org/web/20080917081731/http://www.psilinks.net:80/forum/index.php/topic,50.0.html |
+| psilinks.net/forum | Telepathic Illusion or what? \<Forum thread> | https://web.archive.org/web/20081005173939/http://www.psilinks.net:80/forum/index.php/topic,472.0.html | 
+| psilinks.net/forum | Telepathy With Animals \<Forum thread> | https://web.archive.org/web/20080307025152/http://www.psilinks.net:80/forum/index.php/topic,204.0.html | 
+| psionguild.org/forums | Dreamwalking Question \<Forum thread> | https://web.archive.org/web/20140223155048/http://psionguild.org:80/forums/archive/index.php/t-2615.html | 
+| psionguild.org/forums | Physical Possession \<Forum thread> | https://web.archive.org/web/20140224020657/http://psionguild.org:80/forums/archive/index.php/t-7637.html |
+| psionguild.org/forums | Telepathy and Empathy...with pets \<Forum thread> | https://web.archive.org/web/20140221140348/http://psionguild.org:80/forums/archive/index.php/t-4843.html |
+| psionicsonline.net/forums | Empathic chain? \<Forum thread> | https://web.archive.org/web/20080917050453/http://www.psionicsonline.net:80/forums/empathic-chain | 
 | shiftedperspectives.net | Psi and Insects \<Forum thread> | https://web.archive.org/web/20101223143006/http://shiftedperspectives.net/forum/index.php/topic,1332.0.html |

--- a/index-3-psychokinesis.md
+++ b/index-3-psychokinesis.md
@@ -3,15 +3,15 @@
 ## Intro Guides
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psistudies.net | Psychokinesis Technique \<Gonzo> | https://web.archive.org/web/20071223145454/http://psistudies.net:80/_articles_backup/psychokinesis.html |
-| psionicsonline.net | Macro-Telekinesis Article \<Brandon a.k.a. Magicdood> | https://web.archive.org/web/20080313095033/http://www.psionicsonline.net/macropsychokinesis | 
-| psistudies.net | Psychokinesis Manual \<Apollo> | https://web.archive.org/web/20071204214140/http://psistudies.net:80/_articles_backup/psychokinesisManual_Apollo.html | Combines useful and useless. | 
-| psionicsonline.net | Floats Telekinesis Article \<Float> | https://web.archive.org/web/20111212201651/http://www.psionicsonline.net/floats-telekinesis-article/
-| psionicsonline.net | Telekinesis Techniques \<JoeT> | https://web.archive.org/web/20111212201650/http://www.psionicsonline.net/telekinesis-techniques/ | 
-| psionguild.org/forums | TK Technique for Beginners \<Forum thread> | https://web.archive.org/web/20140223011236/http://psionguild.org:80/forums/archive/index.php/t-7329.html | 
-| thepsiworld.proboards37.com | TK Training Guide \<Forum thread> | https://web.archive.org/web/20061021054855/http://thepsiworld.proboards37.com:80/index.cgi?board=mtel&action=display&thread=1158451655 |  
 | freewebs.com/jedikaren | From Psiwheels to Pencils: A Training Guide \<NeoPsychic> | https://web.archive.org/web/20071221045439/http://www.freewebs.com:80/jedikaren/penciltk.htm |
+| psionguild.org/forums | TK Technique for Beginners \<Forum thread> | https://web.archive.org/web/20140223011236/http://psionguild.org:80/forums/archive/index.php/t-7329.html | 
+| psionicsonline.net | Floats Telekinesis Article \<Float> | https://web.archive.org/web/20111212201651/http://www.psionicsonline.net/floats-telekinesis-article/
+| psionicsonline.net | Macro-Telekinesis Article \<Brandon a.k.a. Magicdood> | https://web.archive.org/web/20080313095033/http://www.psionicsonline.net/macropsychokinesis | 
+| psionicsonline.net | Telekinesis Techniques \<JoeT> | https://web.archive.org/web/20111212201650/http://www.psionicsonline.net/telekinesis-techniques/ | 
+| psistudies.net | Psychokinesis Manual \<Apollo> | https://web.archive.org/web/20071204214140/http://psistudies.net:80/_articles_backup/psychokinesisManual_Apollo.html | Combines useful and useless. | 
 | psipalatium.com | Psychokinesis Overview \<Zeus> | [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=492&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20220626052026/http://www.psipalatium.com:80/index.php?p=202&fltr=Filter&a=492&a1=&p1=&g1=&gp1=&s1=&s=1) |
+| psistudies.net | Psychokinesis Technique \<Gonzo> | https://web.archive.org/web/20071223145454/http://psistudies.net:80/_articles_backup/psychokinesis.html |
+| thepsiworld.proboards37.com | TK Training Guide \<Forum thread> | https://web.archive.org/web/20061021054855/http://thepsiworld.proboards37.com:80/index.cgi?board=mtel&action=display&thread=1158451655 |  
 
 
 
@@ -28,8 +28,8 @@
 ## Specialized applications
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psionicsonline.net/forums | TK on ice \<Forum thread> | https://web.archive.org/web/20080517020707/http://www.psionicsonline.net:80/forums/index.php/topic,623.0.html |
+| astateofmind.eu | Affecting radiowaves \<JoeRoger \[UPC]> | https://web.archive.org/web/20100404012406/http://astateofmind.eu/2008/11/18/affecting-radiowaves/ |
+| freewebs.com/jedikaren | PK: Wind Users Guide \<NeoPsychic> | https://web.archive.org/web/20070708174323/http://www.freewebs.com:80/jedikaren/ak.htm | 
 | psionicsonline.net | Light Dimming \<Alegiojon \[UPC]> | https://web.archive.org/web/20111212201656/http://www.psionicsonline.net/light-dimming-upc/ | 
 | psionicsonline.net | Passive Psychokinetic Force \<Shadowarrior13 \[UPC]> | https://web.archive.org/web/20111212201654/http://www.psionicsonline.net/passive-psychokinetic-force-upc/ | 
-| freewebs.com/jedikaren | PK: Wind Users Guide \<NeoPsychic> | https://web.archive.org/web/20070708174323/http://www.freewebs.com:80/jedikaren/ak.htm | 
-| astateofmind.eum | Affecting radiowaves \<JoeRoger \[UPC]> | https://web.archive.org/web/20100404012406/http://astateofmind.eu/2008/11/18/affecting-radiowaves/ |
+| psionicsonline.net/forums | TK on ice \<Forum thread> | https://web.archive.org/web/20080517020707/http://www.psionicsonline.net:80/forums/index.php/topic,623.0.html |

--- a/index-domains.md
+++ b/index-domains.md
@@ -19,10 +19,10 @@ Inclusion on this list is not, in any way, an endorsement of any kind.
    - ✅ Indexed, nothing useful.
  - psipalatium.com - [Live as of 02/2024](http://www.psipalatium.com/index.php), [WebArchive link](https://web.archive.org/web/*/http://www.psipalatium.com/*) 
    - Same situation as psionicsinstitute.org
-   - [=] In queue.
+   - ✅ Indexed.
  - [psionicsonline.net](https://web.archive.org/web/*/psionicsonline.net*)
    - Need to reinvestigate. IIRC some of this site was structured in a weird way that I never actually accounted for, so some of it was ignored.
-   - [=] In queue.
+   - [-] In progress, see [the branch](https://github.com/libhazeltine/libhazeltine/tree/psionicsonline-v2).
  - psipog.net - [Full site backup from closure](https://web.archive.org/web/20130321035504/http://www.psipog.net/), [WebArchive link](https://web.archive.org/web/*/http://www.psipog.net/*)
    - Compressed archive is more comprehensive than webarchives, so I'll have to manually fill in paths to the selfhosted archive.
    - [=] In queue.

--- a/index-uncategorized.md
+++ b/index-uncategorized.md
@@ -3,54 +3,54 @@
 ## Meditation and Mental Skill Training
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psionicsonline.net | Concentration - The Brain Is A Muscle \<Float> | https://web.archive.org/web/20130327090942/http://www.psionicsonline.net:80/concentration-brain-muscle | 
-| psionicsonline.net | Synergistic Meditation \<ShadowMind\/L.C.> | https://web.archive.org/web/20130327090845/http://www.psionicsonline.net:80/synergistic-meditation
-| psionicsonline.net | Psi-Games \<Sheepking \[UPC]> | https://web.archive.org/web/20100427084733/http://www.psionicsonline.net:80/about-psionics/general-articles/8-psi-games-by-sheepking-upc |
-| psionicvisionaries.blogspot.com | Meditation \<Tantalus> | https://web.archive.org/web/20230622025434/http://psionicvisionaries.blogspot.com/2008/01/meditation.html |
-| psionguild.org | Getting in Focus \<PaleHorse> | https://web.archive.org/web/20120211192315/http://psionguild.org:80/education/articles/foundation/getting-in-focus/
-| psionguild.org | Improving Your Technique \<Maverick1> | https://web.archive.org/web/20120214154228/http://psionguild.org:80/education/articles/foundation/improving-your-technique | 
-| psionguild.org | Concentration Exercise \<Winged Wolf> | https://web.archive.org/web/20120215120646/http://psionguild.org:80/education/articles/foundation/concentration-excercise |
-| freewebs.com/jedikaren | Staying on Topic \<JediKaren> | https://web.archive.org/web/20080102135227/http://www.freewebs.com:80/jedikaren/staying.htm |
 | forums.vsociety.net | A Treatise on Self Hypnosis \<Koujiryuu> | https://web.archive.org/web/20190730090217/http://forums.vsociety.net/index.php/topic,10187.0.html |
-| forums.vsociety.net | Setting Triggers \<ChezNips> | https://web.archive.org/web/20190727180831/http://forums.vsociety.net/index.php/topic,10839.0.html |
-| forums.vsociety.net | Benefits of Meditation \<ChezNips> | https://web.archive.org/web/20140914080607/http://forums.vsociety.net/index.php/topic,10826.0.html |
 | forums.vsociety.net | Altered States \<ChezNips> | https://web.archive.org/web/20140914044502/http://forums.vsociety.net/index.php/topic,10825.0.html |
+| forums.vsociety.net | Benefits of Meditation \<ChezNips> | https://web.archive.org/web/20140914080607/http://forums.vsociety.net/index.php/topic,10826.0.html |
 | forums.vsociety.net | Brain Training \<ChezNips> | https://web.archive.org/web/20180925203804/http://forums.vsociety.net/index.php/topic,10827.0.html |
 | forums.vsociety.net | Relaxation \<Neo> | https://web.archive.org/web/20130512140516/http%253A//forums.vsociety.net/index.php/topic%252C10.0/prev_next%252Cnext.html |
+| forums.vsociety.net | Setting Triggers \<ChezNips> | https://web.archive.org/web/20190727180831/http://forums.vsociety.net/index.php/topic,10839.0.html |
+| freewebs.com/jedikaren | Staying on Topic \<JediKaren> | https://web.archive.org/web/20080102135227/http://www.freewebs.com:80/jedikaren/staying.htm |
+| psionguild.org | Concentration Exercise \<Winged Wolf> | https://web.archive.org/web/20120215120646/http://psionguild.org:80/education/articles/foundation/concentration-excercise |
+| psionguild.org | Getting in Focus \<PaleHorse> | https://web.archive.org/web/20120211192315/http://psionguild.org:80/education/articles/foundation/getting-in-focus/
+| psionguild.org | Improving Your Technique \<Maverick1> | https://web.archive.org/web/20120214154228/http://psionguild.org:80/education/articles/foundation/improving-your-technique | 
+| psionicsonline.net | Concentration - The Brain Is A Muscle \<Float> | https://web.archive.org/web/20130327090942/http://www.psionicsonline.net:80/concentration-brain-muscle | 
+| psionicsonline.net | Psi-Games \<Sheepking \[UPC]> | https://web.archive.org/web/20100427084733/http://www.psionicsonline.net:80/about-psionics/general-articles/8-psi-games-by-sheepking-upc |
+| psionicsonline.net | Synergistic Meditation \<ShadowMind\/L.C.> | https://web.archive.org/web/20130327090845/http://www.psionicsonline.net:80/synergistic-meditation
+| psionicvisionaries.blogspot.com | Meditation \<Tantalus> | https://web.archive.org/web/20230622025434/http://psionicvisionaries.blogspot.com/2008/01/meditation.html |
 | psiscape.net | Visualization/Focusing Exercise \<Forum thread> | https://web.archive.org/web/20060104114520/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=349&amp;sid=ca5e6d801b1ef9233f5f81e9eb54dd05 |
+| zhkyrl.brinkster.net/psionline | Beyond Visualization \<DanielH> | https://web.archive.org/web/20070104125903/http://zhkyrl.brinkster.net:80/psionline/p_beyondvis.html |
 | zhkyrl.brinkster.net/psionline | Keeping Your Focus \<PaleHorse> | https://web.archive.org/web/20070104125023/http://zhkyrl.brinkster.net:80/psionline/b_focus.html |
 | zhkyrl.brinkster.net/psionline | The Basics of Visualization \<DevilsAdvocate> | https://web.archive.org/web/20070112055334/http://zhkyrl.brinkster.net:80/psionline/p_devilvis.html |
-| zhkyrl.brinkster.net/psionline | Beyond Visualization \<DanielH> | https://web.archive.org/web/20070104125903/http://zhkyrl.brinkster.net:80/psionline/p_beyondvis.html |
 
 
 ## Common Problems
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| psistudies.net | Mental Blocks, by \<Lucidess> and \<Gonzo> | https://web.archive.org/web/20080104190040/http://psistudies.net:80/_articles_backup/blocks.html |
-| psionicsonline.net | Troubleshooting Psionics \<InnerFire> | https://web.archive.org/web/20100427085054/http://www.psionicsonline.net:80/about-psionics/general-articles/10-troubleshooting-psionics | 
 | psionicsonline.net | Still Troubleshooting Psionics \<InnerFire> | https://web.archive.org/web/20100427083351/http://www.psionicsonline.net:80/about-psionics/general-articles/17-still-troubleshooting-psionics- | 
+| psionicsonline.net | Troubleshooting Psionics \<InnerFire> | https://web.archive.org/web/20100427085054/http://www.psionicsonline.net:80/about-psionics/general-articles/10-troubleshooting-psionics | 
 | psionguild.org | Long Distance Perception and Scaling \<Winged Wolf> | https://web.archive.org/web/20120215121446/http://psionguild.org:80/education/articles/foundation/long-distance-perception-scaling | 
+| psistudies.net | Mental Blocks, by \<Lucidess> and \<Gonzo> | https://web.archive.org/web/20080104190040/http://psistudies.net:80/_articles_backup/blocks.html |
 
 
 ## Out-of-body Projection
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
+| astateofmind.eu | An Introduction to Remote Touch \<Jonn \[UPC]> | https://web.archive.org/web/20100523120850/http://astateofmind.eu:80/2008/11/19/an-introduction-to-remote-touch/ |
+| freewebs.com/jedikaren | About the Astral Plane \<JediKaren> | https://web.archive.org/web/20071222002836/http://www.freewebs.com:80/jedikaren/howtoap.htm |
+| psc-online.org | Dreamwalking and Lucid Dreaming \<Rainsong> | https://web.archive.org/web/20180507171847/http://psc-online.org/doku.php?id=blog:dreamwalking_and_lucid_dreams |
+| psionguild.org | Drop and Drift Method \<KMiller> | https://web.archive.org/web/20120215145746/http://psionguild.org:80/education/articles/physical-abilities/drop-drift-method/ |
 | psionicsonline.net | Astral Projection: Your First Steps \<Float> | https://web.archive.org/web/20091119001935/http://www.psionicsonline.net:80/article/astral-projection-your-first-steps-float |
 | psionicsonline.net | Out-of-Body Experiences: The Manual \<Metalforever> | https://web.archive.org/web/20091119002600/http://www.psionicsonline.net:80/article/out-body-experiences-manual-metalforever |
-| psionguild.org | Drop and Drift Method \<KMiller> | https://web.archive.org/web/20120215145746/http://psionguild.org:80/education/articles/physical-abilities/drop-drift-method/ |
-| thepsiworld.proboards37.com | The Tibetan Exercise of Paradox \<sash> | https://web.archive.org/web/20061024202940/http://thepsiworld.proboards37.com:80/index.cgi?board=astr&action=display&thread=1144183943 |
-| thepsiworld.proboards37.com | A few methods for AP \<Darin Rosewood> | https://web.archive.org/web/20070527050112/http://thepsiworld.proboards37.com:80/index.cgi?board=astr&action=display&thread=1178480134 |
-| freewebs.com/jedikaren | About the Astral Plane \<JediKaren> | https://web.archive.org/web/20071222002836/http://www.freewebs.com:80/jedikaren/howtoap.htm |
-| astateofmind.eu | An Introduction to Remote Touch \<Jonn \[UPC]> | https://web.archive.org/web/20100523120850/http://astateofmind.eu:80/2008/11/19/an-introduction-to-remote-touch/ |
-| psc-online.org | Dreamwalking and Lucid Dreaming \<Rainsong> | https://web.archive.org/web/20180507171847/http://psc-online.org/doku.php?id=blog:dreamwalking_and_lucid_dreams |
 | thepsiworld.net | Faking AP through Constructs \<Chain the Warforged> | https://web.archive.org/web/20080819132327/http://www.thepsiworld.net:80/forum/index.php/topic,1376.0.html |
+| thepsiworld.proboards37.com | A few methods for AP \<Darin Rosewood> | https://web.archive.org/web/20070527050112/http://thepsiworld.proboards37.com:80/index.cgi?board=astr&action=display&thread=1178480134 |
+| thepsiworld.proboards37.com | The Tibetan Exercise of Paradox \<sash> | https://web.archive.org/web/20061024202940/http://thepsiworld.proboards37.com:80/index.cgi?board=astr&action=display&thread=1144183943 |
 
 
 ## Precognition
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| thepsiworld.proboards37.com | Precognition - Recognizing and Inducing \<xpwarrior3> | https://web.archive.org/web/20061107144959/http://thepsiworld.proboards37.com:80/index.cgi?action=display&amp;board=foreseeing&amp;thread=1132975156&amp;page=1 | 
 | freewebs.com/jedikaren | To Tell or Not To Tell \<JediKaren> | https://web.archive.org/web/20070326180525/http://www.freewebs.com/jedikaren/totell.htm |
+| thepsiworld.proboards37.com | Precognition - Recognizing and Inducing \<xpwarrior3> | https://web.archive.org/web/20061107144959/http://thepsiworld.proboards37.com:80/index.cgi?action=display&amp;board=foreseeing&amp;thread=1132975156&amp;page=1 | 
 
 
 ## Micro-PK
@@ -62,10 +62,10 @@
 ## Offense/Defense
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| freewebs.com/jedikaren | Breaking Shields \<Garenzo> | https://web.archive.org/web/20071221031700/http://www.freewebs.com:80/jedikaren/breakshield.htm
 | astateofmind.eu | Types of psychic attacks & defence against them \<Nathan> | https://web.archive.org/web/20100411013703/http://astateofmind.eu:80/2010/04/08/types-of-psychic-attacks-defence-against-them/ |
 | forums.vsociety.net | Any ways to harm people (besides yourself) doing psi? (1 of 2) \<Forum thread> | https://web.archive.org/web/20130512002800/http%253A//forums.vsociety.net/index.php/topic%252C1013.0.html |
 | forums.vsociety.net | Any ways to harm people (besides yourself) doing psi? (2 of 2) \<Forum thread> | https://web.archive.org/web/20130511221055/http%253A//forums.vsociety.net/index.php/topic%252C1013.15.html |
+| freewebs.com/jedikaren | Breaking Shields \<Garenzo> | https://web.archive.org/web/20071221031700/http://www.freewebs.com:80/jedikaren/breakshield.htm
 | psionline.org | How to Alter Your Signature \<FrozenFlames> | https://web.archive.org/web/20071114083124/http://www.psionline.org:80/2007/10/cullens-guide-to-energy-manipulation.html |
 | psiscape.net | Non-Shielding Defences against Empathy and/or Telepathy \<Forum thread> | https://web.archive.org/web/20060104125631/http://www.psiscape.net:80/phpBB2/viewtopic.php?t=74&amp;start=0&amp;sid=cca37b8afffb4b9eedee37f4967b39c6 |
 | shiftedperspectives.net | Intermediate Combat \<Stolide Demens> | https://web.archive.org/web/20120423020200/http://shiftedperspectives.net/articles.php?id=106 |
@@ -76,19 +76,19 @@
 ## Other
 | Source | Name \[Notes, if any] \<Author> | Link |
 | ------ | ------------------------------- | ---- |
-| youtube.com \[NOT ARCHIVED] | Science and the taboo of psi \<Dean Radin> | https://youtube.com/watch?v=qw_O9Qiwqew | 
-| psionicvisionaries.blogspot.com | Psionics, How To Get Better Without Practice | https://web.archive.org/web/20230622030743/http://psionicvisionaries.blogspot.com/2008/02/psionics-how-to-get-better-without.html | 
-| psionguild.org | Various Exercises for Development of Psi Abilities \<No Author> | https://web.archive.org/web/20120214171930/http://psionguild.org:80/education/articles/foundation/various-exercises-for-development
-| psionguild.org | Introduction to Psionics and Dealing with Skeptics \<KMiller> | https://web.archive.org/web/20110706052309/http://psionguild.org:80/education/articles/foundation/introduction-to-psionics-and-dealing-with-skeptics/ |
-| totse.com | Psionic Training Guide \<Xirokoto> | https://web.archive.org/web/20070520064617/http://www.totse.com/en/fringe/dreams_auras_astral_projection/psionictrainin191367.html | 
 | astateofmind.eu | 5 steps to read an object with psychometry \<Nathan> | https://web.archive.org/web/20100404012436/http://astateofmind.eu:80/2010/04/02/5-steps-to-read-an-object-with-psychometry/ | 
-| ppsociety.com | Another vision on learning TK (Bone breathing) \<Dragor> | https://web.archive.org/web/20050223201453/http://ppsociety.com:80/w_articlev.php?id=9 |
-| shiftedperspectives.net | The Uses of Psi \<JediKaren> | https://web.archive.org/web/20120423020145/http://shiftedperspectives.net:80/articles.php?id=64 |
-| shiftedperspectives.net | Experimenting with Psi \<Notagh> | https://web.archive.org/web/20110915032938/http://shiftedperspectives.net:80/forum/index.php?topic=1921.0 |
-| shiftedperspectives.net | Adfeng's Technique Stash \<The Adfeng> | https://web.archive.org/web/20171210051347/http://shiftedperspectives.net:80/forum/index.php?topic=2811.0 |
-| thepsiworld.net | Tech - a new method to working with energy [*Omnimancy, i believe*] \<Brilenus> | https://web.archive.org/web/20090224072222/http://www.thepsiworld.net:80/forum/index.php?topic=2060.0 |
 | houseofancients.com | What Is Psionics [*This forum is rather unhinged but this thread is interesting*] \<D'Los> | https://web.archive.org/web/20110620081204/http://houseofancients.com:80/forums/viewtopic.php?p=2720&sid=513d21d9ecbd3685606d6aa6215d40d3 |
+| ppsociety.com | Another vision on learning TK (Bone breathing) \<Dragor> | https://web.archive.org/web/20050223201453/http://ppsociety.com:80/w_articlev.php?id=9 |
+| psionguild.org | Introduction to Psionics and Dealing with Skeptics \<KMiller> | https://web.archive.org/web/20110706052309/http://psionguild.org:80/education/articles/foundation/introduction-to-psionics-and-dealing-with-skeptics/ |
+| psionguild.org | Various Exercises for Development of Psi Abilities \<No Author> | https://web.archive.org/web/20120214171930/http://psionguild.org:80/education/articles/foundation/various-exercises-for-development
+| psionicvisionaries.blogspot.com | Psionics, How To Get Better Without Practice | https://web.archive.org/web/20230622030743/http://psionicvisionaries.blogspot.com/2008/02/psionics-how-to-get-better-without.html | 
 | psipalatium.com | Psi and You: You're Doing It Right Now \<Kruel> |  [psipalatium.com link](http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=246&a1=0&p1=0&g1=0&gp1=0&s1=0&s=1) - [web.archive.org link](https://web.archive.org/web/20220116211521/http://www.psipalatium.com/index.php?p=202&fltr=Filter&a=246&a1=&p1=&g1=&gp1=&s1=&s=1) |
+| shiftedperspectives.net | Adfeng's Technique Stash \<The Adfeng> | https://web.archive.org/web/20171210051347/http://shiftedperspectives.net:80/forum/index.php?topic=2811.0 |
+| shiftedperspectives.net | Experimenting with Psi \<Notagh> | https://web.archive.org/web/20110915032938/http://shiftedperspectives.net:80/forum/index.php?topic=1921.0 |
+| shiftedperspectives.net | The Uses of Psi \<JediKaren> | https://web.archive.org/web/20120423020145/http://shiftedperspectives.net:80/articles.php?id=64 |
+| thepsiworld.net | Tech - a new method to working with energy [*Omnimancy, i believe*] \<Brilenus> | https://web.archive.org/web/20090224072222/http://www.thepsiworld.net:80/forum/index.php?topic=2060.0 |
+| totse.com | Psionic Training Guide \<Xirokoto> | https://web.archive.org/web/20070520064617/http://www.totse.com/en/fringe/dreams_auras_astral_projection/psionictrainin191367.html | 
+| youtube.com \[NOT ARCHIVED] | Science and the taboo of psi \<Dean Radin> | https://youtube.com/watch?v=qw_O9Qiwqew | 
 
 
 


### PR DESCRIPTION
When this repository started, the intent was to sort documents in a way where you could click each link and read each thing from the top down, and have each document build on what came before it. As time moved on, the approach shifted towards simply appending documents toward the end of each section. Nowadays, efforts towards beginner-friendly metaphysical resources are being put elsewhere, and this project is now solely oriented towards data preservation.

Because of this, documents in indexes are now sorted by domain and title rather than percieved value. As a result, indexes and sections are now considered categories rather a progressive advancement reading path. 

This is also necessary to make it easier to organize the planned document backups, both in the archives repo and in glassport.